### PR TITLE
Add laximo QueryDataLogin method authorization and response adaptation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,26 @@ Laximo.options.ssl_verify         false
 Laximo.options.timeout            10
 Laximo.options.debug              false
 ```
+или для авторизации по подписке
+```ruby
+Laximo.options.use_ssl            true
+Laximo.options.use_login          true
+Laximo.options.login              'mylogin'    # имейте в виду, что такие параметры
+Laximo.options.password           'mypassword' # должны быть вынесены в переменные окружения
+Laximo.options.ssl_verify         false
+
+Laximo.options.timeout            10
+Laximo.options.debug              false
+```
 
 ### Конфигурация
   * `Laximo.options.ssl_key "путь_к_файлу"` — путь к открытому ключу ssl-сертификата
   * `Laximo.options.ssl_cert "путь_к_файлу"` — путь к закрытому ключу ssl-сертификата
   * `Laximo.options.ssl_cert true/false` — проверять или нет валидность сертификата. **В случае самоподписанного сертификата, проверку на валидность необходимо отключить**
   * `Laximo.options.use_ssl true/false` - использовать ssl-соединение или нет
+  * `Laximo.options.use_login true/false` - использовать авторизацию по подписке или нет
+  * `Laximo.options.login` - логин для авторизации по подписке
+  * `Laximo.options.password` - пароль для авторизации по подписке
   * `Laximo.options.timeout 30` - таймаут соединения в секундах (по-умочланию, 10)
   * `Laximo.options.user_agent "Ваш_юзер_агент"` - задание произвольного юзер-агента (по-умолчанию, "LaximoRuby [версия_библиотеки]")
   * `Laximo.options.debug true/false` - включение/отключение режима отладки (по-умолчанию, выключено)
@@ -107,7 +121,7 @@ res.error    # <Laximo::SoapInvalidParameterError: UnitId>
 res.result   # []
 ```
 
-Помимо переисленного списка ошибок, в ответе могут быть возвращены стандартные ошибки библиотеки `Net::HTTP` и интерпретатора Ruby.
+Помимо перечисленного списка ошибок, в ответе могут быть возвращены стандартные ошибки библиотеки `Net::HTTP` и интерпретатора Ruby.
 
 ### Лицензия
 

--- a/lib/laximo/options.rb
+++ b/lib/laximo/options.rb
@@ -5,6 +5,27 @@ module Laximo
 
     extend self
 
+    def use_login(str = nil)
+
+      return @use_login if str.nil?
+      @use_login = str === true
+
+    end # use login
+
+    def login(str = nil)
+
+      return @login if str.nil?
+      @login = str
+
+    end # login
+
+    def password(str = nil)
+
+      return @password if str.nil?
+      @password = str
+
+    end # password
+
     def ssl_key(str = nil)
 
       return @ssl_key if str.nil?

--- a/lib/laximo/respond.rb
+++ b/lib/laximo/respond.rb
@@ -6,6 +6,7 @@ module Laximo
     class Base
 
       RESPONSE_RESULT     = '//QueryDataResponse/return'.freeze
+      RESPONSE_LOGIN_RESULT = '//QueryDataLoginResponse/return'.freeze
       RESPONSE_SOAP_ERROR = '//Fault/faultstring'.freeze
 
       def initialize(request)
@@ -122,11 +123,15 @@ module Laximo
           doc = ::Nokogiri::XML(http.body)
           doc.remove_namespaces!
 
-          res = doc.xpath(RESPONSE_RESULT).children[0].to_s
+          if ::Laximo.options.use_login
+            res = doc.xpath(RESPONSE_LOGIN_RESULT).children[0].to_s
+          else
+            res = doc.xpath(RESPONSE_RESULT).children[0].to_s
+          end
 
           @error  = nil
           @result = parsing_result(
-            ::Nokogiri::XML(unescape(res))
+              ::Nokogiri::XML(unescape(res))
           ) || []
 
         rescue => ex


### PR DESCRIPTION
Добавил возможность авторизации по подписке и распознавания ответа через QueryDataLogin.
Стоит иметь в виду, что у них проблемы на сервере для сервиса Aftermarket.
